### PR TITLE
Feat/handler ordering tests

### DIFF
--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -331,4 +331,77 @@ class KafkaProxyInitializerTest {
         orderedVerifyer.verify(channelPipeline).addLast(eq("saslV0Rejecter"), any(SaslV0RejectionHandler.class));
         orderedVerifyer.verify(channelPipeline).addLast(eq("responseOrderer"), any(ResponseOrderer.class));
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldAddHAProxyHandlersInCorrectOrder(boolean tls) {
+        // Given - HAProxy protocol enabled
+        virtualClusterModel = buildVirtualCluster(false, false);
+        when(endpointBinding.endpointGateway()).thenReturn(virtualClusterModel.gateways().values().iterator().next());
+
+        // Create initializer with HAProxy enabled (haproxyProtocol = true)
+        kafkaProxyInitializer = createKafkaProxyInitializerWithHAProxy(tls, (endpoint, sniHostname) -> bindingStage, true);
+
+        // When
+        kafkaProxyInitializer.addHandlers(channel, endpointBinding);
+
+        // Then - verify ordering using InOrder
+        final InOrder orderedVerifier = inOrder(channelPipeline);
+
+        // First remove error handler
+        verifyErrorHandlerRemoved(orderedVerifier);
+
+        // Then HAProxyMessageDecoder must be added
+        orderedVerifier.verify(channelPipeline).addLast(eq("HAProxyMessageDecoder"), any(io.netty.handler.codec.haproxy.HAProxyMessageDecoder.class));
+
+        // Immediately followed by HAProxyMessageHandler
+        orderedVerifier.verify(channelPipeline).addLast(eq("HAProxyMessageHandler"), any(HAProxyMessageHandler.class));
+
+        // Then other handlers (decoder, encoder, etc.)
+        verifyEncoderAndOrdererAdded(orderedVerifier);
+
+        // Then frontend handler
+        verifyFrontendHandlerAdded(orderedVerifier);
+
+        // Then error handler re-added
+        verifyErrorHandlerAdded(orderedVerifier);
+
+        Mockito.verifyNoMoreInteractions(channelPipeline);
+    }
+
+    /**
+     * Test that HAProxy handlers are NOT added when HAProxy protocol is disabled.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldNotAddHAProxyHandlersWhenDisabled(boolean tls) {
+        // Given - HAProxy protocol disabled (default)
+        virtualClusterModel = buildVirtualCluster(false, false);
+        when(endpointBinding.endpointGateway()).thenReturn(virtualClusterModel.gateways().values().iterator().next());
+        kafkaProxyInitializer = createKafkaProxyInitializer(tls, (endpoint, sniHostname) -> bindingStage);
+
+        // When
+        kafkaProxyInitializer.addHandlers(channel, endpointBinding);
+
+        // Then - verify HAProxy handlers are NOT added
+        verify(channelPipeline, Mockito.never()).addLast(eq("HAProxyMessageDecoder"), any());
+        verify(channelPipeline, Mockito.never()).addLast(eq("HAProxyMessageHandler"), any());
+    }
+
+    /**
+     * Helper method to create KafkaProxyInitializer with HAProxy protocol support.
+     */
+    private KafkaProxyInitializer createKafkaProxyInitializerWithHAProxy(
+            boolean tls,
+            EndpointBindingResolver bindingResolver,
+            boolean haproxyProtocol) {
+        return new KafkaProxyInitializer(
+                filterChainFactory,
+                pfr,
+                tls,
+                bindingResolver,
+                (virtualCluster, upstreamNodes) -> null,
+                haproxyProtocol,
+                new ApiVersionsServiceImpl());
+    }
 }


### PR DESCRIPTION
---
 # Summary

  This PR adds comprehensive handler ordering tests to complement PR #3071 (Move filters to frontend handler).

 # Motivation

  PR #3071 introduces a critical but fragile dependency on Netty handler ordering:
  - HAProxyMessageHandler must come before FilterHandler instances
  - FilterHandler instances must come before KafkaProxyFrontendHandler

  Without these tests, refactoring could accidentally reorder handlers, causing:
  - Filters to see HAProxyMessage and crash
  - State machine to not receive HAProxy messages correctly
  - Messages to bypass filters entirely

 # Changes

  Commit 1: Unit Tests (KafkaProxyInitializerTest)

  Added two parameterized tests using Mockito InOrder verification:

  1. shouldAddHAProxyHandlersInCorrectOrder - Validates:
    - HAProxyMessageDecoder added before HAProxyMessageHandler
    - HAProxyMessageHandler added before codecs/filters/frontend handler
    - Ordering enforced when HAProxy protocol is enabled
  2. shouldNotAddHAProxyHandlersWhenDisabled - Validates:
    - HAProxy handlers not added when protocol is disabled
    - Prevents false positives from unrelated handlers
  3. createKafkaProxyInitializerWithHAProxy - Helper method to create initializer with HAProxy support enabled

  Commit 2: Integration Test (ProxyChannelStateMachineEndToEndTest)

  Added end-to-end test using real EmbeddedChannel:

  1. shouldMaintainCorrectHandlerOrderingAfterFiltersInstalled - Validates:
    - Complete pipeline ordering after ClientActive state transition
    - HAProxyMessageHandler → FilterHandler → KafkaProxyFrontendHandler
    - Real runtime configuration, not just initialization mocks
  2. Helper methods:
    - findHandlerIndex() - Locates handler instance in pipeline
    - findFirstFilterHandler() - Finds first filter by naming convention

##  Test Coverage
  ┌──────────────────┬────────────────┬────────────────────────────────────────────────┐
  │       Test       │     Scope      │               What It Validates                │
  ├──────────────────┼────────────────┼────────────────────────────────────────────────┤
  │ Unit tests       │ Initialization │ Handler addition order during pipeline setup   │
  ├──────────────────┼────────────────┼────────────────────────────────────────────────┤
  │ Integration test │ End-to-end     │ Runtime pipeline state after filters installed │
  └──────────────────┴────────────────┴────────────────────────────────────────────────┘
  
 # Verification

  All tests pass:
  mvn test -Dtest=KafkaProxyInitializerTest#should*HAProxy* -Dquick
  mvn test -Dtest=ProxyChannelStateMachineEndToEndTest#shouldMaintainCorrectHandlerOrderingAfterFiltersInstalled -Dquick